### PR TITLE
Removed deprecated asyncore import

### DIFF
--- a/scanme.py
+++ b/scanme.py
@@ -1,6 +1,5 @@
 # !/usr/bin/env python
 
-from asyncore import write
 import subprocess
 import threading
 import sys


### PR DESCRIPTION
asyncore was deprecated in Python 3.6 and removed in Python 3.12. This update removes the unused import to ensure compatibility.